### PR TITLE
add package-query and minor fix on yaourt

### DIFF
--- a/package-query/PKGBUILD
+++ b/package-query/PKGBUILD
@@ -1,0 +1,24 @@
+# Contributor: tuxce <tuxce.net@gmail.com>
+# Contributor: Skunnyk <skunnyk@archlinux.fr>
+pkgname=package-query
+pkgver=1.9
+pkgrel=1
+pkgdesc="Query ALPM and AUR"
+arch=('i686' 'x86_64' 'mips64el' 'armv6h' 'armv7h' 'arm' 'aarch64')
+url="https://github.com/archlinuxfr/package-query/"
+license=('GPL')
+depends=('pacman>=5.0' 'yajl>=2.0')
+source=(https://mir.archlinux.fr/releases/$pkgname/$pkgname-$pkgver.tar.gz)
+sha256sums=('88bc3970fd05a16778c52d5aafc19e930aadd0d6b4c6b142f8fff47ec22ef785')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  ./configure --localstatedir=/var --prefix=/usr --sysconfdir=/etc --with-aur-url=https://aur.archlinux.org
+  make
+}
+
+package ()
+{
+  cd "$srcdir/$pkgname-$pkgver"
+  make DESTDIR="$pkgdir" install
+}

--- a/yaourt/PKGBUILD
+++ b/yaourt/PKGBUILD
@@ -10,9 +10,7 @@ arch=('any')
 url="https://github.com/archlinuxfr/$pkgname"
 license=(GPL)
 depends=('diffutils' 'pacman>=5.0' 'package-query>=1.8' 'gettext')
-optdepends=('aurvote: vote for favorite packages from AUR'
-            'customizepkg: automatically modify PKGBUILD during install/upgrade'
-            'rsync: retrieve PKGBUILD from official repositories')
+optdepends=('rsync: retrieve PKGBUILD from official repositories')
 backup=('etc/yaourtrc')
 source=("$url/releases/download/$pkgver/$pkgname-$pkgver.tar.gz" '0001-alpm-artix-brand.patch')
 sha256sums=('9a485cef9d50e80b8abae5dbb147e09bdeb8818d29316b65e892fb560c48517d'


### PR DESCRIPTION
This pull request will add `package-query` to testing and remove `aurvote` and `customizepkg` from yaourt 's optdepends

Thanks!